### PR TITLE
Freebsd support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,7 +98,7 @@ class timezone (
   }
 
   file { $timezone::params::localtime_file:
-    ensure  => $localtime_ensure,
-    target  => "${timezone::params::zoneinfo_dir}${timezone}",
+    ensure => $localtime_ensure,
+    target => "${timezone::params::zoneinfo_dir}${timezone}",
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,6 +74,7 @@ class timezone (
   if $timezone::params::package {
     package { $timezone::params::package:
       ensure => $package_ensure,
+      before => File[$timezone::params::localtime_file],
     }
   }
 
@@ -99,9 +100,5 @@ class timezone (
   file { $timezone::params::localtime_file:
     ensure  => $localtime_ensure,
     target  => "${timezone::params::zoneinfo_dir}${timezone}",
-    require => $::osfamily ? {
-      FreeBSD => undef,
-      default => Package[$timezone::params::package],
-    },
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,8 +43,8 @@
 #
 # [Remember: No empty lines between comments and class definition]
 class timezone (
-  $ensure = 'present',
-  $timezone = 'UTC',
+  $ensure      = 'present',
+  $timezone    = 'UTC',
   $autoupgrade = false
 ) inherits timezone::params {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,7 +71,7 @@ class timezone (
     }
   }
 
-  if $package != undef {
+  if $timezone::params::package {
     package { $timezone::params::package:
       ensure => $package_ensure,
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,7 +47,6 @@ class timezone::params {
       $zoneinfo_dir = '/usr/share/zoneinfo/'
       $localtime_file = '/etc/localtime'
       $timezone_file = false
-      $timezone_update = 'adjkerntz -a'
     }
     default: {
       case $::operatingsystem {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,6 +47,7 @@ class timezone::params {
       $zoneinfo_dir = '/usr/share/zoneinfo/'
       $localtime_file = '/etc/localtime'
       $timezone_file = false
+      $timezone_update = 'adjkerntz -a'
     }
     default: {
       case $::operatingsystem {


### PR DESCRIPTION
This PR updates your "freebsd-support" branch to resolve a couple of minor things.  The travis-ci build was failing for your PR, so this aims to resolve that.
- Use the "before" metaparameter for the relationship between the package and localtime file.  We don't use the a package on FreeBSD, so you previously had a selector within the file resource to set require to "undef" if FreeBSD.  The selector within a resource is against the Puppet Labs style guide, so it caused puppet-lint to fail (causing the travis-ci build to fail).  This fixes all that by using "before" on the package.  If the package is in the catalog, it'll set the relationship correctly.
- Evaluate the package variable correctly.  You had "if $package != undef", but "$package" wasn't a valid variable.  saz is making reference to the package variable in params, so this PR updates your logic to evaluate if THAT variable is present.  In the case of FreeBSD, it's not, so the package resource is ignored (as we want).
